### PR TITLE
Update domoticz.cpp to manage the redirection of stderr to a logging …

### DIFF
--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -172,7 +172,6 @@ bool g_bUseWatchdog = true;
 
 std::string daemonname = DAEMON_NAME;
 std::string m_sz_std_out_err_log_file="";
-#define STD_OUT_ERR_LOG_FILE "/var/log/std_out_err.log"
 std::string pidfile = PID_FILE;
 int pidFilehandle = 0;
 
@@ -282,7 +281,7 @@ void daemonize(const char *rundir, const char *pidfile)
 	/* Route I/O connections */
 
 	/* Open STDIN */
-	if (m_sz_std_out_err_log_file=="")	
+	if (m_sz_std_out_err_log_file.empty())	
 		i = open("/dev/null", O_RDWR);
 	else
 		i = open(m_sz_std_out_err_log_file.c_str(), O_RDWR | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
@@ -633,10 +632,7 @@ bool ParseConfigFile(const std::string &szConfigFile)
 			FixFolderEnding(szUserDataFolder);
 		}
 		else if (szFlag == "std_out_err_log_file") {	
-			if (sLine=="") 
-				m_sz_std_out_err_log_file = STD_OUT_ERR_LOG_FILE;
-			else
-				m_sz_std_out_err_log_file = sLine;
+			m_sz_std_out_err_log_file = sLine;
 		}
 		else if (szFlag == "daemon_name") {
 			daemonname = sLine;
@@ -1126,7 +1122,7 @@ int main(int argc, char**argv)
 	if (!bUseConfigFile) {
 		if (cmdLine.HasSwitch("-std_out_err_log_file"))		
 		{
-			m_sz_std_out_err_log_file = cmdLine.GetSafeArgument("-std_out_err_log_file", 0, STD_OUT_ERR_LOG_FILE);
+			m_sz_std_out_err_log_file = cmdLine.GetSafeArgument("-std_out_err_log_file", 0, "");
 		}
 		if (cmdLine.HasSwitch("-daemon"))
 		{

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -156,6 +156,7 @@ std::string weblogfile;
 bool g_bStopApplication = false;
 bool g_bUseSyslog = false;
 bool g_bRunAsDaemon = false;
+bool g_bredirect_stdin_stdout_stderr = false;
 http::server::_eWebCompressionMode g_wwwCompressMode = http::server::WWW_USE_GZIP;
 bool g_bUseUpdater = true;
 http::server::server_settings webserver_settings;
@@ -168,9 +169,11 @@ bool bStartWebBrowser = true;
 bool g_bUseWatchdog = true;
 
 #define DAEMON_NAME "domoticz"
+#define REDIRECT_STDIN_STDOUT_STDERR_FILENAME "/var/log/stdin_stdout_stderr.log"
 #define PID_FILE "/var/run/domoticz.pid" 
 
 std::string daemonname = DAEMON_NAME;
+std::string redirect_stdin_stdout_stderr=REDIRECT_STDIN_STDOUT_STDERR_FILENAME;
 std::string pidfile = PID_FILE;
 int pidFilehandle = 0;
 
@@ -280,7 +283,10 @@ void daemonize(const char *rundir, const char *pidfile)
 	/* Route I/O connections */
 
 	/* Open STDIN */
-	i = open("/dev/null", O_RDWR);
+	if (g_bredirect_stdin_stdout_stderr)	
+		i = open(redirect_stdin_stdout_stderr.c_str(), O_RDWR | O_APPEND | O_CREAT);
+	else
+		i = open("/dev/null", O_RDWR);
 
 	/* STDOUT */
 	int dret = dup(i);
@@ -626,6 +632,12 @@ bool ParseConfigFile(const std::string &szConfigFile)
 		else if (szFlag == "userdata_path") {
 			szUserDataFolder = sLine;
 			FixFolderEnding(szUserDataFolder);
+		}
+		else if (szFlag == "redirect_stdin_stdout_stderr") {	
+			g_bredirect_stdin_stdout_stderr = GetConfigBool(sLine);
+		}
+		else if (szFlag == "redirect_stdin_stdout_stderr_filename") {	
+			redirect_stdin_stdout_stderr = sLine;
 		}
 		else if (szFlag == "daemon_name") {
 			daemonname = sLine;
@@ -1113,6 +1125,11 @@ int main(int argc, char**argv)
 
 #ifndef WIN32
 	if (!bUseConfigFile) {
+		if (cmdLine.HasSwitch("-redirect_stdin_stdout_stderr"))		
+		{
+			g_bredirect_stdin_stdout_stderr = true;
+			redirect_stdin_stdout_stderr = cmdLine.GetSafeArgument("-redirect_stdin_stdout_stderr", 0, REDIRECT_STDIN_STDOUT_STDERR_FILENAME);
+		}
 		if (cmdLine.HasSwitch("-daemon"))
 		{
 			g_bRunAsDaemon = true;

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -284,7 +284,7 @@ void daemonize(const char *rundir, const char *pidfile)
 
 	/* Open STDIN */
 	if (g_bredirect_stdin_stdout_stderr)	
-		i = open(redirect_stdin_stdout_stderr.c_str(), O_RDWR | O_APPEND | O_CREAT);
+		i = open(redirect_stdin_stdout_stderr.c_str(), O_RDWR | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	else
 		i = open("/dev/null", O_RDWR);
 


### PR DESCRIPTION
…file

Create a tag "g_bredirect_stdin_stdout_stderr" to initiate the redirection of stderr to a logging file when domoticz is run as a service. Usage in domoticz.sh : add a line 
DAEMON_ARGS="$DAEMON_ARGS -redirect_stdin_stdout_stderr /var/log/stdin_out_err.log" to redirect the stderr messages to the file /var/log/stdin_out_err.log